### PR TITLE
Consider adding support for "relative" bookmarks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,76 @@ Now every time you log in, the abbreviated `to` command will be available and al
 
     to --help
 
+# Usage
+
+## Absolute Bookmarks
+
+Traditional directory bookmarks store absolute paths.  Invoking `to <bookmark>`
+never depends on your current path.
+
+```console
+# Set a bookmark "stable" to the current dir, /home/user/git/cool-browser-stable
+$ cd /home/user/git/cool-browser-stable
+/home/user/git/cool-browser-stable
+$ to -s stable
+
+# Set a bookmark "trunk" by providing the full path
+$ to -s trunk /home/user/git/cool-browser-trunk
+
+# Set an unrelated bookmark "games" that is named using the current directory.
+$ cd /usr/local/games
+/usr/local/games
+$ to -s
+
+# go to the "stable" bookmark
+$ to stable
+/home/user/git/cool-browser-stable
+
+# go to the "trunk" bookmark
+$ to trunk
+/home/user/git/cool-browser-trunk
+
+# go to the "games" bookmark
+$ to games
+/usr/local/games
+```
+
+## Relative Bookmarks
+
+Relative bookmarks save paths that are interpreted in the context of absolute
+bookmarks.  They are useful when you have parallel directory structures, like
+when you have multiple checkouts of a single source code repository.  Invoking
+`to <relative bookmark>` searches the database for the absolute bookmark that
+matches the current directory, applies the relative bookmark's path to that
+absolute directory, then changes to that path.
+
+```console
+# Switch to the "stable" absolute bookmark we previously created.
+$ to stable
+/home/user/git/cool-browser-stable
+
+# Change to a really long sub-directory.
+$ cd deep/hard-to-type/subdir/so/so/long
+/home/user/git/cool-browser-stable/deep/hard-to-type/subdir/so/so/long
+
+# Set a relative bookmark "longish" to the current dir, relative to the current "stable" bookmark.
+$ to -r longish
+
+# Go to the "trunk" absolute bookmark
+$ to trunk
+/home/user/git/cool-browser-trunk
+
+# Go to the "longish" relative bookmark under "trunk"
+$ to longish
+/home/user/git/cool-browser-trunk/deep/hard-to-type/subdir/so/so/long
+
+# But this will not work if the directory does not exist.
+$ to games
+/usr/local/games
+$ to longish
+error: Path does not exist "/usr/local/games/deep/hard-to-type/subdir/so/so/long".
+```
+
 # Development
 
 ## Debugging

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,6 +45,11 @@ pub fn app<'a, 'b>() -> clap::App<'a, 'b> {
             .short("s")
             .help("Save bookmark")
             .takes_value(false))
+        .arg(clap::Arg::with_name("save-relative")
+            .long("save-relative")
+            .short("r")
+            .help("Save relative bookmark")
+            .takes_value(false))
         .arg(clap::Arg::with_name("delete")
             .long("delete")
             .short("d")
@@ -75,6 +80,7 @@ pub enum Action {
     Info,
     List,
     Save,
+    SaveRelative,
     Pathname,
 }
 
@@ -103,18 +109,20 @@ impl Options {
     /// assert_eq!(options.action, cli::Action::Pathname);
     /// ```
     pub fn new(matches: clap::ArgMatches) -> Result<Options> {
-        let (delete, info, list, save) = (
+        let (delete, info, list, save, save_relative) = (
             matches.is_present("delete"),
             matches.is_present("info"),
             matches.is_present("list"),
             matches.is_present("save"),
+            matches.is_present("save-relative"),
         );
 
-        let action = match (delete, info, list, save) {
-            (true, _, _, _) => Action::Delete,
-            (_, true, _, _) => Action::Info,
-            (_, _, true, _) => Action::List,
-            (_, _, _, true) => Action::Save,
+        let action = match (delete, info, list, save, save_relative) {
+            (true, _, _, _, _) => Action::Delete,
+            (_, true, _, _, _) => Action::Info,
+            (_, _, true, _, _) => Action::List,
+            (_, _, _, true, _) => Action::Save,
+            (_, _, _, _, true) => Action::SaveRelative,
             _ => Action::Pathname,
         };
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -117,24 +117,27 @@ impl Database {
     // determine if the bookmark should be relative.  When navigating to a path given only a single
     // bookmark name, the current directory is passed to determine the correct absolute path base.
     pub fn find_longest_path_prefix_match(&self, value: &PathBuf) -> Option<&Bookmark> {
-        self.bookmarks.iter().fold(None, |best_so_far, (_, ref bookmark)| {
-            let ref dir = bookmark.directory;
-            // Is the bookmark a prefix of our path?
-            if dir.is_absolute() && value.starts_with(dir) {
-                // Is the best match so far still the longest?  Keep using it if so.
-                if let Some(x) = best_so_far {
-                    if x.directory.starts_with(dir) {
-                        return best_so_far;
+        self.bookmarks.iter().fold(
+            None,
+            |best_so_far, (_, ref bookmark)| {
+                let ref dir = bookmark.directory;
+                // Is the bookmark a prefix of our path?
+                if dir.is_absolute() && value.starts_with(dir) {
+                    // Is the best match so far still the longest?  Keep using it if so.
+                    if let Some(x) = best_so_far {
+                        if x.directory.starts_with(dir) {
+                            return best_so_far;
+                        }
                     }
+
+                    // We either had no existing candidate or the new bookmark is better.
+                    return Some(&bookmark);
                 }
 
-                // We either had no existing candidate or the new bookmark is better.
-                return Some(&bookmark);
-            }
-
-            // The bookmark's not a candidate, the existing best candidate holds.
-            return best_so_far;
-        })
+                // The bookmark's not a candidate, the existing best candidate holds.
+                return best_so_far;
+            },
+        )
     }
 
     // Invoke find_longest_path_prefix_match, and if a bookmark is found, return value with the

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,10 @@ fn save_relative(store: &mut Database, key: String, value: PathBuf) -> Result<()
     if let Some(stripped_path) = store.strip_longest_path_prefix_match(&value) {
         store.put(key, stripped_path.to_path_buf())
     } else {
-        println!("New bookmark path '{:?}' doesn't match any existing absolute bookmarks!",
-                 value);
+        println!(
+            "New bookmark path '{:?}' doesn't match any existing absolute bookmarks!",
+            value
+        );
         Ok(())
     }
 }
@@ -102,11 +104,16 @@ fn list(store: &Database) -> Result<()> {
     Ok(())
 }
 
-fn maybe_transform_relative_bookmark(store: &Database, bookmark: &Bookmark,
-                                     effective_dir: PathBuf) -> PathBuf {
+fn maybe_transform_relative_bookmark(
+    store: &Database,
+    bookmark: &Bookmark,
+    effective_dir: PathBuf,
+) -> PathBuf {
     if bookmark.directory.is_relative() {
         if let Some(absolute_bookmark) = store.find_longest_path_prefix_match(&effective_dir) {
-            absolute_bookmark.directory.join(bookmark.directory.as_path().clone())
+            absolute_bookmark
+                .directory
+                .join(bookmark.directory.as_path().clone())
         } else {
             bookmark.directory.clone()
         }
@@ -121,8 +128,7 @@ fn pathname(store: &Database, options: cli::Options) -> Result<()> {
         Err(_) => bail!(ErrorKind::CurrentDirectoryError(PathBuf::from("."))),
     };
     let value = match store.get(&options.name) {
-        Some(bookmark) =>
-            maybe_transform_relative_bookmark(store, bookmark, effective_dir),
+        Some(bookmark) => maybe_transform_relative_bookmark(store, bookmark, effective_dir),
         None => bail!(ErrorKind::BookmarkNotFound(options.name)),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,12 @@ extern crate prettytable;
 #[macro_use]
 extern crate slog;
 
+use std::env::current_dir;
 use std::path::PathBuf;
 use prettytable::Table;
 use to::{cli, dir, logger};
 use to::cli::Action;
+use to::database::Bookmark;
 use to::database::Database;
 use to::errors::*;
 
@@ -60,6 +62,7 @@ fn run(matches: cli::ArgMatches) -> Result<()> {
     match options.action {
         Action::Info => info(&store, &options),
         Action::Save => store.put(options.name, options.path),
+        Action::SaveRelative => save_relative(&mut store, options.name, options.path),
         Action::Delete => store.delete(options.name),
         Action::List => list(&store),
         Action::Pathname => pathname(&store, options),
@@ -73,6 +76,16 @@ fn info(store: &Database, options: &cli::Options) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn save_relative(store: &mut Database, key: String, value: PathBuf) -> Result<()> {
+    if let Some(stripped_path) = store.strip_longest_path_prefix_match(&value) {
+        store.put(key, stripped_path.to_path_buf())
+    } else {
+        println!("New bookmark path '{:?}' doesn't match any existing absolute bookmarks!",
+                 value);
+        Ok(())
+    }
 }
 
 fn list(store: &Database) -> Result<()> {
@@ -89,13 +102,31 @@ fn list(store: &Database) -> Result<()> {
     Ok(())
 }
 
+fn maybe_transform_relative_bookmark(store: &Database, bookmark: &Bookmark,
+                                     effective_dir: PathBuf) -> PathBuf {
+    if bookmark.directory.is_relative() {
+        if let Some(absolute_bookmark) = store.find_longest_path_prefix_match(&effective_dir) {
+            absolute_bookmark.directory.join(bookmark.directory.as_path().clone())
+        } else {
+            bookmark.directory.clone()
+        }
+    } else {
+        bookmark.directory.clone()
+    }
+}
+
 fn pathname(store: &Database, options: cli::Options) -> Result<()> {
+    let effective_dir = match current_dir() {
+        Ok(dir) => dir,
+        Err(_) => bail!(ErrorKind::CurrentDirectoryError(PathBuf::from("."))),
+    };
     let value = match store.get(&options.name) {
-        Some(bookmark) => bookmark.directory.to_string_lossy(),
+        Some(bookmark) =>
+            maybe_transform_relative_bookmark(store, bookmark, effective_dir),
         None => bail!(ErrorKind::BookmarkNotFound(options.name)),
     };
 
-    println!("{}", value);
+    println!("{}", value.to_string_lossy());
 
     Ok(())
 }


### PR DESCRIPTION
Use case: I maintain multiple working directory checkouts of the same code-base.  These parallel trees all share the same relative paths that are hard to remember.  Rather than having to manually create permutations of each bookmark for each tree, it would be nice if there was a way to support relative bookmarks.

This pull request attempts to do that by adding an explicit "-r" "--save-relative" command that:
* Locates the most specific existing absolute bookmark that's a prefix of the new bookmark.
* Strips the absolute bookmark's path off the path.
* Saves that relative path to the database.  There's no boolean flags stored, Path's `is_relative` method is used to determine when a bookmark is relative for navigation.

Then when normal `to <bookmark> [path that's usually ommited and the current_dir is used]` things happen, if the bookmark is relative, the command:
* Locates the most specific existing absolute bookmark that's a prefix of the provided path.
* Joins the relative bookmark path to that absolute bookmark path.
* Returns that.

The patch does not currently support `to <absolute bookmark> <relative bookmark>`, although that seems like something that would be nice.  There's also no tests because the existing tests don't seem quite there yet and I figured I'd get your feedback on whether you want such a feature and how you'd like such tests implemented before trying my hand at that.

Context: I'm a rust neophyte and current [CDargs](http://www.skamphausen.de/cgi-bin/ska/CDargs/) user.  Although there are a lot of projects in this feature-space, I was unable to readily find any that supported relative bookmarks.  As an aspirational rust fanperson, I was delighted to find this project and try my hand at adding relative bookmark support.  It's cool if this isn't a fit for your project or you'd like me to restructure things or just file an issue, etc.  Thanks for creating this cool project!